### PR TITLE
Add basic idle game

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,11 @@
-# Idle Space Miner
+# Idle Space Miner Deluxe
 
-Dieses Repo enthält ein kleines Browser-Idle-Game.
+Ein React-basiertes Idle/Incremental-Game mit mehreren Ressourcen.
 Öffne `index.html` in einem aktuellen Browser, um zu spielen.
 
 ## Features
-- Staub sammeln durch Klicks
-- Auto-Sammler kaufen
-- Laser-Booster für höhere Produktion
-- Prestige-System mit dauerhaften Produktionsboni
-- Erfolge (Achievements)
-- Automatisches Speichern mit LocalStorage
+- Drei Ressourcen: Erz, Kristall und Energie
+- Arbeiter und Upgrades zur automatischen Produktion
+- Offline-Fortschritt, zufällige Meteor-Events und Achievements
+- Prestige-System mit Sternen und globalem Produktionsbonus
+- React-UI mit automatischem Speichern via LocalStorage

--- a/README
+++ b/README
@@ -1,1 +1,12 @@
-Hier soll ein Idle Game entstehen
+# Idle Space Miner
+
+Dieses Repo enthält ein kleines Browser-Idle-Game.
+Öffne `index.html` in einem aktuellen Browser, um zu spielen.
+
+## Features
+- Staub sammeln durch Klicks
+- Auto-Sammler kaufen
+- Laser-Booster für höhere Produktion
+- Prestige-System mit dauerhaften Produktionsboni
+- Erfolge (Achievements)
+- Automatisches Speichern mit LocalStorage

--- a/index.html
+++ b/index.html
@@ -3,34 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Idle Space Miner</title>
+  <title>Idle Space Miner Deluxe</title>
   <link rel="stylesheet" href="style.css" />
+  <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
 </head>
 <body>
-  <h1>Idle Space Miner</h1>
-  <div id="resource-display">Staub: <span id="dust">0</span></div>
-  <button id="collect">Sammeln</button>
-
-  <div id="upgrades">
-    <h2>Upgrades</h2>
-    <button id="buy-auto" class="upgrade">
-      Auto-Sammler (<span id="auto-count">0</span>) - Kosten: <span id="auto-cost">10</span>
-    </button>
-    <button id="buy-multiplier" class="upgrade">
-      Laser-Booster (<span id="multiplier-level">1</span>x) - Kosten: <span id="multiplier-cost">50</span>
-    </button>
-  </div>
-
-  <div id="achievements">
-    <h2>Erfolge</h2>
-    <ul id="ach-list"></ul>
-  </div>
-
-  <div id="prestige">
-    <h2>Prestige</h2>
-    <button id="prestige-btn">Prestige (+<span id="prestige-points">0</span>% Produktion)</button>
-  </div>
-
+  <div id="root"></div>
   <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Idle Space Miner</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Idle Space Miner</h1>
+  <div id="resource-display">Staub: <span id="dust">0</span></div>
+  <button id="collect">Sammeln</button>
+
+  <div id="upgrades">
+    <h2>Upgrades</h2>
+    <button id="buy-auto" class="upgrade">
+      Auto-Sammler (<span id="auto-count">0</span>) - Kosten: <span id="auto-cost">10</span>
+    </button>
+    <button id="buy-multiplier" class="upgrade">
+      Laser-Booster (<span id="multiplier-level">1</span>x) - Kosten: <span id="multiplier-cost">50</span>
+    </button>
+  </div>
+
+  <div id="achievements">
+    <h2>Erfolge</h2>
+    <ul id="ach-list"></ul>
+  </div>
+
+  <div id="prestige">
+    <h2>Prestige</h2>
+    <button id="prestige-btn">Prestige (+<span id="prestige-points">0</span>% Produktion)</button>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,122 @@
+let dust = 0;
+let dustPerClick = 1;
+let autoCount = 0;
+let autoCost = 10;
+let multiplier = 1;
+let multiplierCost = 50;
+let prestigePoints = 0;
+let achievements = new Set();
+
+function updateDisplay() {
+  document.getElementById('dust').textContent = Math.floor(dust);
+  document.getElementById('auto-count').textContent = autoCount;
+  document.getElementById('auto-cost').textContent = autoCost;
+  document.getElementById('multiplier-level').textContent = multiplier;
+  document.getElementById('multiplier-cost').textContent = multiplierCost;
+  document.getElementById('prestige-points').textContent = prestigePoints;
+}
+
+document.getElementById('collect').addEventListener('click', () => {
+  dust += dustPerClick * multiplier * (1 + prestigePoints / 100);
+  updateDisplay();
+  checkAchievements();
+});
+
+document.getElementById('buy-auto').addEventListener('click', () => {
+  if (dust >= autoCost) {
+    dust -= autoCost;
+    autoCount++;
+    autoCost = Math.floor(autoCost * 1.5);
+    updateDisplay();
+    checkAchievements();
+  }
+});
+
+document.getElementById('buy-multiplier').addEventListener('click', () => {
+  if (dust >= multiplierCost) {
+    dust -= multiplierCost;
+    multiplier++;
+    multiplierCost = Math.floor(multiplierCost * 2);
+    updateDisplay();
+    checkAchievements();
+  }
+});
+
+setInterval(() => {
+  dust += autoCount * multiplier * (1 + prestigePoints / 100);
+  updateDisplay();
+  checkAchievements();
+}, 1000);
+
+function checkAchievements() {
+  if (dust >= 100 && !achievements.has('hundert')) {
+    achievements.add('hundert');
+    addAchievement('Erstes Hundert!');
+  }
+  if (dust >= 1000 && !achievements.has('tausend')) {
+    achievements.add('tausend');
+    addAchievement('Staub-Experte!');
+  }
+  if (autoCount >= 10 && !achievements.has('auto10')) {
+    achievements.add('auto10');
+    addAchievement('Automatischer Kapitalist!');
+  }
+  if (multiplier >= 5 && !achievements.has('multi5')) {
+    achievements.add('multi5');
+    addAchievement('Laser-Show!');
+  }
+}
+
+function addAchievement(text) {
+  const li = document.createElement('li');
+  li.textContent = text;
+  document.getElementById('ach-list').appendChild(li);
+}
+
+document.getElementById('prestige-btn').addEventListener('click', () => {
+  const gained = Math.floor(dust / 1000);
+  if (gained > 0) {
+    prestigePoints += gained;
+    dust = 0;
+    autoCount = 0;
+    autoCost = 10;
+    multiplier = 1;
+    multiplierCost = 50;
+    achievements.clear();
+    document.getElementById('ach-list').innerHTML = '';
+    updateDisplay();
+    addAchievement(`Prestige +${gained}% Produktion!`);
+  }
+});
+
+function saveGame() {
+  const save = {
+    dust,
+    autoCount,
+    autoCost,
+    multiplier,
+    multiplierCost,
+    prestigePoints,
+    achievements: Array.from(achievements),
+  };
+  localStorage.setItem('idleSave', JSON.stringify(save));
+}
+
+function loadGame() {
+  const saveStr = localStorage.getItem('idleSave');
+  if (!saveStr) return;
+  const save = JSON.parse(saveStr);
+  dust = save.dust || 0;
+  autoCount = save.autoCount || 0;
+  autoCost = save.autoCost || 10;
+  multiplier = save.multiplier || 1;
+  multiplierCost = save.multiplierCost || 50;
+  prestigePoints = save.prestigePoints || 0;
+  achievements = new Set(save.achievements || []);
+  achievements.forEach(addAchievement);
+  updateDisplay();
+}
+
+loadGame();
+updateDisplay();
+setInterval(saveGame, 3000);

--- a/script.js
+++ b/script.js
@@ -1,122 +1,223 @@
-let dust = 0;
-let dustPerClick = 1;
-let autoCount = 0;
-let autoCost = 10;
-let multiplier = 1;
-let multiplierCost = 50;
-let prestigePoints = 0;
-let achievements = new Set();
-
-function updateDisplay() {
-  document.getElementById('dust').textContent = Math.floor(dust);
-  document.getElementById('auto-count').textContent = autoCount;
-  document.getElementById('auto-cost').textContent = autoCost;
-  document.getElementById('multiplier-level').textContent = multiplier;
-  document.getElementById('multiplier-cost').textContent = multiplierCost;
-  document.getElementById('prestige-points').textContent = prestigePoints;
-}
-
-document.getElementById('collect').addEventListener('click', () => {
-  dust += dustPerClick * multiplier * (1 + prestigePoints / 100);
-  updateDisplay();
-  checkAchievements();
-});
-
-document.getElementById('buy-auto').addEventListener('click', () => {
-  if (dust >= autoCost) {
-    dust -= autoCost;
-    autoCount++;
-    autoCost = Math.floor(autoCost * 1.5);
-    updateDisplay();
-    checkAchievements();
-  }
-});
-
-document.getElementById('buy-multiplier').addEventListener('click', () => {
-  if (dust >= multiplierCost) {
-    dust -= multiplierCost;
-    multiplier++;
-    multiplierCost = Math.floor(multiplierCost * 2);
-    updateDisplay();
-    checkAchievements();
-  }
-});
-
-setInterval(() => {
-  dust += autoCount * multiplier * (1 + prestigePoints / 100);
-  updateDisplay();
-  checkAchievements();
-}, 1000);
-
-function checkAchievements() {
-  if (dust >= 100 && !achievements.has('hundert')) {
-    achievements.add('hundert');
-    addAchievement('Erstes Hundert!');
-  }
-  if (dust >= 1000 && !achievements.has('tausend')) {
-    achievements.add('tausend');
-    addAchievement('Staub-Experte!');
-  }
-  if (autoCount >= 10 && !achievements.has('auto10')) {
-    achievements.add('auto10');
-    addAchievement('Automatischer Kapitalist!');
-  }
-  if (multiplier >= 5 && !achievements.has('multi5')) {
-    achievements.add('multi5');
-    addAchievement('Laser-Show!');
-  }
-}
-
-function addAchievement(text) {
-  const li = document.createElement('li');
-  li.textContent = text;
-  document.getElementById('ach-list').appendChild(li);
-}
-
-document.getElementById('prestige-btn').addEventListener('click', () => {
-  const gained = Math.floor(dust / 1000);
-  if (gained > 0) {
-    prestigePoints += gained;
-    dust = 0;
-    autoCount = 0;
-    autoCost = 10;
-    multiplier = 1;
-    multiplierCost = 50;
-    achievements.clear();
-    document.getElementById('ach-list').innerHTML = '';
-    updateDisplay();
-    addAchievement(`Prestige +${gained}% Produktion!`);
-  }
-});
-
-function saveGame() {
-  const save = {
-    dust,
-    autoCount,
-    autoCost,
-    multiplier,
-    multiplierCost,
-    prestigePoints,
-    achievements: Array.from(achievements),
-  };
-  localStorage.setItem('idleSave', JSON.stringify(save));
-}
+const e = React.createElement;
+const ACHIEVEMENTS = [
+  { id: 'ore100', text: 'Sammle 100 Erz', check: g => g.resources.ore >= 100 },
+  { id: 'ore1000', text: 'Sammle 1.000 Erz', check: g => g.resources.ore >= 1000 },
+  { id: 'miner10', text: 'Besitze 10 Miner', check: g => g.workers.miner >= 10 },
+  { id: 'crystal1', text: 'Erhalte einen Kristall', check: g => g.resources.crystal >= 1 },
+  { id: 'energy1', text: 'Erhalte Energie', check: g => g.resources.energy >= 1 },
+  { id: 'prestige1', text: 'Führe Prestige aus', check: g => g.prestige.stars >= 1 }
+];
 
 function loadGame() {
-  const saveStr = localStorage.getItem('idleSave');
-  if (!saveStr) return;
-  const save = JSON.parse(saveStr);
-  dust = save.dust || 0;
-  autoCount = save.autoCount || 0;
-  autoCost = save.autoCost || 10;
-  multiplier = save.multiplier || 1;
-  multiplierCost = save.multiplierCost || 50;
-  prestigePoints = save.prestigePoints || 0;
-  achievements = new Set(save.achievements || []);
-  achievements.forEach(addAchievement);
-  updateDisplay();
+  try {
+    const data = JSON.parse(localStorage.getItem('idleReactSave'));
+    if (data) return { ...data, lastTick: Date.now() };
+  } catch (e) {}
+  return {
+    resources: { ore: 0, crystal: 0, energy: 0 },
+    perClick: { ore: 1 },
+    workers: { miner: 0, extractor: 0, generator: 0 },
+    costs: { miner: 10, extractor: 100, generator: 1000, clickUpgrade: 50, workerUpgrade: 250 },
+    multiplier: { click: 1, worker: 1 },
+    prestige: { stars: 0 },
+    achievements: {},
+    lastTick: Date.now()
+  };
 }
 
-loadGame();
-updateDisplay();
-setInterval(saveGame, 3000);
+function saveGame(game) {
+  try {
+    localStorage.setItem('idleReactSave', JSON.stringify(game));
+  } catch (e) {}
+}
+
+function App() {
+  const [game, setGame] = React.useState(loadGame());
+  const [tab, setTab] = React.useState('mine');
+  const [message, setMessage] = React.useState('');
+
+  // offline progress
+  React.useEffect(() => {
+    setGame(g => {
+      const now = Date.now();
+      const diff = Math.floor((now - g.lastTick) / 1000);
+      if (diff <= 0) return g;
+      const pm = 1 + g.prestige.stars * 0.2;
+      return {
+        ...g,
+        resources: {
+          ore: g.resources.ore + g.workers.miner * g.multiplier.worker * pm * diff,
+          crystal: g.resources.crystal + g.workers.extractor * g.multiplier.worker * pm * diff,
+          energy: g.resources.energy + g.workers.generator * g.multiplier.worker * pm * diff
+        },
+        lastTick: now
+      };
+    });
+  }, []);
+
+  // tick + autosave
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      setGame(g => {
+        const pm = 1 + g.prestige.stars * 0.2;
+        const oreGain = g.workers.miner * g.multiplier.worker * pm;
+        const crystalGain = g.workers.extractor * g.multiplier.worker * pm;
+        const energyGain = g.workers.generator * g.multiplier.worker * pm;
+        const newGame = {
+          ...g,
+          resources: {
+            ore: g.resources.ore + oreGain,
+            crystal: g.resources.crystal + crystalGain,
+            energy: g.resources.energy + energyGain
+          },
+          lastTick: Date.now()
+        };
+        saveGame(newGame);
+        return newGame;
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // random events
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      if (Math.random() < 0.1) {
+        const reward = Math.floor(50 + Math.random() * 50);
+        setGame(g => ({ ...g, resources: { ...g.resources, ore: g.resources.ore + reward } }));
+        setMessage(`Meteor gefunden! +${reward} Erz`);
+        setTimeout(() => setMessage(''), 4000);
+      }
+    }, 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  // achievements
+  React.useEffect(() => {
+    ACHIEVEMENTS.forEach(a => {
+      if (!game.achievements[a.id] && a.check(game)) {
+        setGame(g => ({ ...g, achievements: { ...g.achievements, [a.id]: true } }));
+      }
+    });
+  }, [game]);
+
+  const prestigeMult = 1 + game.prestige.stars * 0.2;
+
+  const mine = () => {
+    setGame(g => ({
+      ...g,
+      resources: { ...g.resources, ore: g.resources.ore + g.perClick.ore * g.multiplier.click * prestigeMult }
+    }));
+  };
+
+  const buyWorker = type => {
+    setGame(g => {
+      const cost = g.costs[type];
+      if (g.resources.ore < cost) return g;
+      return {
+        ...g,
+        resources: { ...g.resources, ore: g.resources.ore - cost },
+        workers: { ...g.workers, [type]: g.workers[type] + 1 },
+        costs: { ...g.costs, [type]: Math.floor(cost * 1.15) }
+      };
+    });
+  };
+
+  const buyClickUpgrade = () => {
+    setGame(g => {
+      const cost = g.costs.clickUpgrade;
+      if (g.resources.crystal < cost) return g;
+      return {
+        ...g,
+        resources: { ...g.resources, crystal: g.resources.crystal - cost },
+        multiplier: { ...g.multiplier, click: g.multiplier.click + 1 },
+        costs: { ...g.costs, clickUpgrade: Math.floor(cost * 2) }
+      };
+    });
+  };
+
+  const buyWorkerUpgrade = () => {
+    setGame(g => {
+      const cost = g.costs.workerUpgrade;
+      if (g.resources.energy < cost) return g;
+      return {
+        ...g,
+        resources: { ...g.resources, energy: g.resources.energy - cost },
+        multiplier: { ...g.multiplier, worker: parseFloat((g.multiplier.worker + 0.5).toFixed(1)) },
+        costs: { ...g.costs, workerUpgrade: Math.floor(cost * 2) }
+      };
+    });
+  };
+
+  const doPrestige = () => {
+    setGame(g => {
+      const total = g.resources.ore + g.resources.crystal + g.resources.energy;
+      const gain = Math.floor(total / 10000);
+      if (gain <= 0) return g;
+      const newGame = {
+        resources: { ore: 0, crystal: 0, energy: 0 },
+        perClick: { ore: 1 },
+        workers: { miner: 0, extractor: 0, generator: 0 },
+        costs: { miner: 10, extractor: 100, generator: 1000, clickUpgrade: 50, workerUpgrade: 250 },
+        multiplier: { click: 1, worker: 1 },
+        prestige: { stars: g.prestige.stars + gain },
+        achievements: g.achievements,
+        lastTick: Date.now()
+      };
+      saveGame(newGame);
+      return newGame;
+    });
+  };
+
+  const renderTab = () => {
+    switch (tab) {
+      case 'mine':
+        return e('div', null,
+          e('div', { className: 'resource' }, `Erz: ${Math.floor(game.resources.ore)}`),
+          e('div', { className: 'resource' }, `Kristall: ${Math.floor(game.resources.crystal)}`),
+          e('div', { className: 'resource' }, `Energie: ${Math.floor(game.resources.energy)}`),
+          e('button', { onClick: mine }, `Erz abbauen (+${game.perClick.ore * game.multiplier.click * prestigeMult})`),
+          message ? e('div', { className: 'message' }, message) : null
+        );
+      case 'upgrades':
+        return e('div', null,
+          e('h3', null, 'Arbeiter'),
+          e('button', { onClick: () => buyWorker('miner') }, `Miner (${game.workers.miner}) - Kosten: ${game.costs.miner} Erz`),
+          e('button', { onClick: () => buyWorker('extractor') }, `Extractor (${game.workers.extractor}) - Kosten: ${game.costs.extractor} Erz`),
+          e('button', { onClick: () => buyWorker('generator') }, `Generator (${game.workers.generator}) - Kosten: ${game.costs.generator} Erz`),
+          e('h3', null, 'Upgrades'),
+          e('button', { onClick: buyClickUpgrade }, `Click-Stufe (${game.multiplier.click}x) - Kosten: ${game.costs.clickUpgrade} Kristall`),
+          e('button', { onClick: buyWorkerUpgrade }, `Arbeiter-Stufe (${game.multiplier.worker.toFixed(1)}x) - Kosten: ${game.costs.workerUpgrade} Energie`)
+        );
+      case 'achievements':
+        return e('ul', { id: 'achievements' },
+          ACHIEVEMENTS.filter(a => game.achievements[a.id]).map(a =>
+            e('li', { key: a.id }, a.text)
+          )
+        );
+      case 'prestige':
+        const total = game.resources.ore + game.resources.crystal + game.resources.energy;
+        const gain = Math.floor(total / 10000);
+        return e('div', null,
+          e('p', null, `Sterne: ${game.prestige.stars} (x${(1 + game.prestige.stars * 0.2).toFixed(1)} Produktion)`),
+          e('p', null, `Prestige-Bonus verfügbar: +${gain} Sterne`),
+          e('button', { onClick: doPrestige }, 'Prestige')
+        );
+      default:
+        return null;
+    }
+  };
+
+  return e('div', null,
+    e('h1', null, 'Idle Space Miner Deluxe'),
+    e('div', { id: 'tabs' },
+      e('button', { onClick: () => setTab('mine') }, 'Mine'),
+      e('button', { onClick: () => setTab('upgrades') }, 'Upgrades'),
+      e('button', { onClick: () => setTab('achievements') }, 'Achievements'),
+      e('button', { onClick: () => setTab('prestige') }, 'Prestige')
+    ),
+    renderTab()
+  );
+}
+
+ReactDOM.render(e(App), document.getElementById('root'));

--- a/style.css
+++ b/style.css
@@ -7,9 +7,14 @@ body {
   padding: 0;
 }
 
-#resource-display {
-  font-size: 24px;
+#tabs {
+  display: flex;
+  justify-content: center;
   margin: 20px 0;
+}
+
+#tabs button {
+  margin: 0 5px;
 }
 
 button {
@@ -28,26 +33,25 @@ button:disabled {
   cursor: not-allowed;
 }
 
-#upgrades,
-#achievements,
-#prestige {
-  margin-top: 20px;
+.resource {
+  font-size: 22px;
+  margin: 5px;
 }
 
-.upgrade {
-  display: block;
-  width: 80%;
-  margin: 10px auto;
-}
-
-#ach-list {
+#achievements {
   list-style: none;
   padding: 0;
 }
 
-#ach-list li {
-  background: rgba(0, 0, 0, 0.2);
-  margin: 5px;
-  padding: 5px;
-  border-radius: 3px;
+#achievements li {
+  background: rgba(0, 0, 0, 0.3);
+  margin: 5px auto;
+  padding: 5px 10px;
+  border-radius: 4px;
+  width: 80%;
+}
+
+.message {
+  margin-top: 10px;
+  color: #ffd700;
 }

--- a/style.css
+++ b/style.css
@@ -1,0 +1,53 @@
+body {
+  font-family: 'Segoe UI', sans-serif;
+  text-align: center;
+  background: linear-gradient(180deg, #101020, #202040);
+  color: #fff;
+  margin: 0;
+  padding: 0;
+}
+
+#resource-display {
+  font-size: 24px;
+  margin: 20px 0;
+}
+
+button {
+  padding: 10px 20px;
+  margin: 5px;
+  border: none;
+  border-radius: 5px;
+  background: #4caf50;
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: #888;
+  cursor: not-allowed;
+}
+
+#upgrades,
+#achievements,
+#prestige {
+  margin-top: 20px;
+}
+
+.upgrade {
+  display: block;
+  width: 80%;
+  margin: 10px auto;
+}
+
+#ach-list {
+  list-style: none;
+  padding: 0;
+}
+
+#ach-list li {
+  background: rgba(0, 0, 0, 0.2);
+  margin: 5px;
+  padding: 5px;
+  border-radius: 3px;
+}


### PR DESCRIPTION
## Summary
- build simple browser-based idle game with click, auto-sammler, multiplier, achievements and prestige
- persist progress via localStorage and add light CSS styling

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688c53b2ca74832db1058ecce8a29c69